### PR TITLE
chore(renovate): enable platformAutomerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "automerge": true,
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],


### PR DESCRIPTION
Renovate's built-in automerge waits for *every* CI check on a PR, including non-required "advisory" checks — which is why dependency-bump PRs have been sitting open despite `automerge: true` already being configured here. `platformAutomerge: true` delegates the merge decision to GitHub's native auto-merge, which only waits on branch-protection-required checks. Config-only change, no effect on application behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/bluefin-cli/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->