### PR TITLE
docs(release): document classic PAT requirement for winget PR automation (closes #110)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -173,7 +173,9 @@ winget:
     ids:
       - standard
     # Skip until the WINGET_TOKEN secret is configured, so a missing token
-    # can't fail the release.
+    # can't fail the release. Note: WINGET_TOKEN must be a classic PAT with
+    # public_repo scope (fine-grained PATs cannot open PRs against upstream
+    # microsoft/winget-pkgs; see tuna-os/bluefin-cli#110).
     skip_upload: '{{ if envOrDefault "WINGET_TOKEN" "" }}auto{{ else }}true{{ end }}'
     # Submissions to microsoft/winget-pkgs must come from a fork: goreleaser
     # pushes the manifest branch to the token owner's fork and opens the PR

--- a/docs/adr/0003-release-pipeline.md
+++ b/docs/adr/0003-release-pipeline.md
@@ -15,7 +15,9 @@ bucket, AUR, winget — every publisher self-gates with
 `skip_upload: {{ if envOrDefault "SECRET" "" }}auto{{ else }}true{{ end }}`
 so a missing secret can never fail a release. Repository `token`/
 `private_key` fields render in goreleaser's env-only mode: plain
-`{{ .Env.X }}` only, no functions. Self-update (`internal/update`) refuses
+`{{ .Env.X }}` only, no functions. `WINGET_TOKEN` must be a classic PAT with
+`public_repo` scope to enable opening PRs against upstream `microsoft/winget-pkgs`
+(fine-grained PATs return 403; see #110). Self-update (`internal/update`) refuses
 archives that don't match the release's checksums.txt.
 
 ## Consequences


### PR DESCRIPTION
Documents that `WINGET_CREATE_GITHUB_TOKEN` / `WINGET_TOKEN` secret requires a classic Personal Access Token with `public_repo` scope in `.goreleaser.yaml` and `docs/adr/0003-release-pipeline.md`. Fine-grained PATs return 403 when opening PRs against upstream `microsoft/winget-pkgs`. Closes #110.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/bluefin-cli/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->