### PR TITLE
fix: install curated bundles on Alpine/postmarketOS

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -138,16 +138,12 @@ func applyPackageChanges(toInstall, toRemove []install.Package) {
 		}
 	} else {
 		if len(toInstall) > 0 {
-			if err := install.InstallBrewPackages(toInstall); err != nil {
+			if err := install.InstallPackages(toInstall); err != nil {
 				fmt.Println(tui.ErrorStyle.Render(fmt.Sprintf("Install error: %v", err)))
 			}
 		}
 		if len(toRemove) > 0 {
-			ids := make([]string, 0, len(toRemove))
-			for _, p := range toRemove {
-				ids = append(ids, p.Name)
-			}
-			if err := install.UninstallBrewPackages(ids); err != nil {
+			if err := install.UninstallPackages(toRemove); err != nil {
 				fmt.Println(tui.ErrorStyle.Render(fmt.Sprintf("Uninstall error: %v", err)))
 			}
 		}

--- a/internal/install/alpine_installer.go
+++ b/internal/install/alpine_installer.go
@@ -1,0 +1,145 @@
+//go:build !windows
+
+package install
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// AlpineInstaller installs the formula portion of Brewfile bundles using the
+// Alpine package universe. Casks and flatpaks have no general Alpine
+// equivalent and are reported as unavailable rather than sent to apk.
+type AlpineInstaller struct{}
+
+func (i *AlpineInstaller) InstallBundle(names ...string) error {
+	var packages []Package
+	for _, name := range names {
+		path, cleanup, err := GetBrewfile(name)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+		bundlePackages, err := GetBrewfilePackages(path)
+		if err != nil {
+			return err
+		}
+		packages = append(packages, bundlePackages...)
+	}
+	return InstallAlpinePackages(packages)
+}
+
+func (i *AlpineInstaller) InstallWallpapers([]string) error {
+	return fmt.Errorf("wallpaper casks are not available on Alpine/postmarketOS")
+}
+
+func (i *AlpineInstaller) CleanupWallpapers(bool) error { return nil }
+
+// InstallAlpinePackages installs each supported package independently so one
+// package absent from Alpine does not prevent the rest of a bundle installing.
+func InstallAlpinePackages(packages []Package) error {
+	manager, err := alpinePackageManager()
+	if err != nil {
+		return err
+	}
+
+	installed, skipped, failed := 0, 0, 0
+	for _, pkg := range packages {
+		if !isAlpinePackage(pkg) {
+			skipped++
+			continue
+		}
+		name := alpinePackageName(pkg.ID)
+		fmt.Println(infoStyle.Render(fmt.Sprintf("⬇️  Installing %s via %s...", name, manager)))
+		if err := runAlpineInstall(manager, name); err != nil {
+			failed++
+			fmt.Println(errorStyle.Render(fmt.Sprintf("  unavailable or failed: %s (%v)", name, err)))
+			continue
+		}
+		installed++
+	}
+
+	if skipped > 0 || failed > 0 {
+		fmt.Println(infoStyle.Render(fmt.Sprintf("Alpine bundle result: %d installed, %d unavailable, %d failed.", installed, skipped, failed)))
+	}
+	if installed == 0 && (skipped > 0 || failed > 0) {
+		return fmt.Errorf("no supported packages from bundle were installed")
+	}
+	return nil
+}
+
+func UninstallAlpinePackages(packages []Package) error {
+	manager, err := alpinePackageManager()
+	if err != nil {
+		return err
+	}
+	for _, pkg := range packages {
+		if !isAlpinePackage(pkg) {
+			continue
+		}
+		name := alpinePackageName(pkg.ID)
+		var cmd *exec.Cmd
+		if manager == "coldbrew" {
+			cmd = exec.Command(manager, "uninstall", name)
+		} else {
+			cmd = exec.Command("sudo", "apk", "del", name)
+		}
+		cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Println(errorStyle.Render(fmt.Sprintf("Failed to uninstall %s: %v", name, err)))
+		}
+	}
+	return nil
+}
+
+func alpinePackageManager() (string, error) {
+	if _, err := exec.LookPath("coldbrew"); err == nil {
+		return "coldbrew", nil
+	}
+	if _, err := exec.LookPath("apk"); err != nil {
+		return "", fmt.Errorf("neither coldbrew nor apk was found; install one before installing Alpine bundles")
+	}
+	return "apk", nil
+}
+
+func runAlpineInstall(manager, name string) error {
+	var cmd *exec.Cmd
+	if manager == "coldbrew" {
+		cmd = exec.Command(manager, "install", name)
+	} else {
+		cmd = exec.Command("sudo", "apk", "add", name)
+	}
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	if manager == "coldbrew" {
+		wrap := exec.Command(manager, "wrap", name)
+		wrap.Stdout, wrap.Stderr = os.Stdout, os.Stderr
+		return wrap.Run()
+	}
+	return nil
+}
+
+var alpinePackageAliases = map[string]string{
+	"gh":                  "github-cli",
+	"kubernetes-cli":      "kubectl",
+	"dapr/tap/dapr-cli":   "dapr",
+	"buildpacks/tap/pack": "pack-cli",
+}
+
+func alpinePackageName(id string) string {
+	if name, ok := alpinePackageAliases[id]; ok {
+		return name
+	}
+	if idx := strings.LastIndex(id, "/"); idx >= 0 {
+		id = id[idx+1:]
+	}
+	return id
+}
+
+func isAlpinePackage(pkg Package) bool {
+	return pkg.Kind == "brew"
+}

--- a/internal/install/alpine_installer_test.go
+++ b/internal/install/alpine_installer_test.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package install
+
+import "testing"
+
+func TestAlpinePackageName(t *testing.T) {
+	tests := map[string]string{
+		"gh":                  "github-cli",
+		"kubernetes-cli":      "kubectl",
+		"dapr/tap/dapr-cli":   "dapr",
+		"buildpacks/tap/pack": "pack-cli",
+		"artifacthub/cmd/ah":  "ah",
+		"tap/formula":         "formula",
+		"ripgrep":             "ripgrep",
+	}
+	for input, want := range tests {
+		t.Run(input, func(t *testing.T) {
+			if got := alpinePackageName(input); got != want {
+				t.Fatalf("alpinePackageName(%q) = %q, want %q", input, got, want)
+			}
+		})
+	}
+}
+
+func TestAlpineInstallerSkipsUnsupportedKinds(t *testing.T) {
+	for _, test := range []struct {
+		pkg  Package
+		want bool
+	}{
+		{Package{ID: "codex", Kind: "cask"}, false},
+		{Package{ID: "org.gnome.Calculator", Kind: "flatpak"}, false},
+		{Package{ID: "kubectl", Kind: "brew"}, true},
+	} {
+		if got := isAlpinePackage(test.pkg); got != test.want {
+			t.Errorf("isAlpinePackage(%+v) = %v, want %v", test.pkg, got, test.want)
+		}
+	}
+}

--- a/internal/install/installer.go
+++ b/internal/install/installer.go
@@ -1,5 +1,7 @@
 package install
 
+import "github.com/tuna-os/bluefin-cli/internal/env"
+
 // Installer defines the interface for platform-specific installation operations.
 type Installer interface {
 	InstallBundle(nameOrPath ...string) error
@@ -17,4 +19,14 @@ func SetInstaller(i Installer) {
 // GetInstaller returns the current global installer.
 func GetInstaller() Installer {
 	return currentInstaller
+}
+
+// initInstaller selects the installer for the current Unix-like platform.
+// Windows has its own installer in windows_installer.go.
+func initInstaller(unix, alpine Installer) {
+	if env.IsAlpine() {
+		SetInstaller(alpine)
+		return
+	}
+	SetInstaller(unix)
 }

--- a/internal/install/packages.go
+++ b/internal/install/packages.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"github.com/tuna-os/bluefin-cli/internal/env"
 )
 
 // Package is a cross-platform representation of a single installable package.
@@ -127,7 +129,21 @@ func MarkInstalled(pkgs []Package) []Package {
 	if runtime.GOOS == "windows" {
 		return markInstalledWinget(pkgs)
 	}
+	if env.IsAlpine() {
+		return markInstalledAlpine(pkgs)
+	}
 	return markInstalledBrew(pkgs)
+}
+
+func markInstalledAlpine(pkgs []Package) []Package {
+	result := make([]Package, len(pkgs))
+	for i, p := range pkgs {
+		if p.Kind == "brew" {
+			p.Installed = exec.Command("apk", "info", "-e", alpinePackageName(p.ID)).Run() == nil
+		}
+		result[i] = p
+	}
+	return result
 }
 
 // InstalledCasks returns the set of installed Homebrew casks (short names);
@@ -233,6 +249,9 @@ func UninstallWingetPackages(ids []string) error {
 // InstallBrewPackages installs a list of brew formulae/casks.
 // Formulae and casks are batched into separate single commands.
 func InstallBrewPackages(pkgs []Package) error {
+	if env.IsAlpine() {
+		return InstallAlpinePackages(pkgs)
+	}
 	var formulae, casks []string
 	for _, p := range pkgs {
 		if p.Kind == "cask" {
@@ -262,4 +281,24 @@ func InstallBrewPackages(pkgs []Package) error {
 		}
 	}
 	return nil
+}
+
+// InstallPackages dispatches the shared menu operation to the native package
+// manager for the current platform.
+func InstallPackages(pkgs []Package) error {
+	if env.IsAlpine() {
+		return InstallAlpinePackages(pkgs)
+	}
+	return InstallBrewPackages(pkgs)
+}
+
+func UninstallPackages(pkgs []Package) error {
+	if env.IsAlpine() {
+		return UninstallAlpinePackages(pkgs)
+	}
+	names := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		names = append(names, p.Name)
+	}
+	return UninstallBrewPackages(names)
 }

--- a/internal/install/unix_installer.go
+++ b/internal/install/unix_installer.go
@@ -9,15 +9,20 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/tuna-os/bluefin-cli/internal/env"
 )
 
 type UnixInstaller struct{}
 
 func init() {
-	SetInstaller(&UnixInstaller{})
+	initInstaller(&UnixInstaller{}, &AlpineInstaller{})
 }
 
 func (i *UnixInstaller) InstallBundle(packages ...string) error {
+	if env.IsAlpine() {
+		return (&AlpineInstaller{}).InstallBundle(packages...)
+	}
 	if _, err := exec.LookPath("brew"); err != nil {
 		return fmt.Errorf("homebrew not found. Please install Homebrew first: https://brew.sh")
 	}


### PR DESCRIPTION
## What changed
- add an Alpine installer for curated and custom Brewfile bundles
- use coldbrew when available, with `sudo apk` fallback
- translate known Homebrew formula names to Alpine package names
- skip unsupported casks/flatpaks and report partial bundle results
- route the interactive Install Apps flow through the platform package manager

## Why
Homebrew cannot run on Alpine/postmarketOS because it requires glibc. The existing Unix installer therefore failed before installing any bundle package.

## Validation
- `go test ./...`
- `GOOS=windows GOARCH=amd64 go test ./internal/install ./cmd`
- `git diff --check`

Fixes #112

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/bluefin-cli/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788937402&installation_model_id=429180&pr_number=139&repository=tuna-os%2Fbluefin-cli&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2Fbluefin-cli%2Fpull%2F139&signature=c56b80da42600acc158fdea7b1cefffdec3c2c90347c59123c02b2d70ba827ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->