### PR TITLE
docs: document Scoop bucket publishing secret (#91)

### DIFF
--- a/docs/release-publishing.md
+++ b/docs/release-publishing.md
@@ -1,0 +1,34 @@
+# Release publishing credentials
+
+GoReleaser publishes the Windows Scoop manifest to
+[`tuna-os/scoop-bucket`](https://github.com/tuna-os/scoop-bucket). The release
+workflow passes the repository secret `SCOOP_BUCKET_TOKEN` to GoReleaser, and
+`.goreleaser.yaml` skips the Scoop upload when that variable is empty.
+
+## One-time administrator setup
+
+An organization administrator should create a fine-grained GitHub token with:
+
+- repository access restricted to `tuna-os/scoop-bucket`;
+- repository permission `Contents: Read and write`.
+
+Store the token in the `tuna-os/bluefin-cli` repository as the Actions secret
+named exactly:
+
+```text
+SCOOP_BUCKET_TOKEN
+```
+
+The token must belong to an account that can push to the bucket's `main`
+branch. Do not put it in the workflow file, `.goreleaser.yaml`, or a fork.
+
+## Verification
+
+After adding the secret, trigger a release from a release tag and check the
+GoReleaser output for the Scoop publisher. The generated manifest should land
+in `tuna-os/scoop-bucket` on `main`.
+
+Without the secret, releases intentionally remain green and publish the other
+configured channels; the Scoop publisher is skipped. This makes the setting
+safe to test in forks and pull requests without exposing or requiring the
+organization credential.


### PR DESCRIPTION
## Summary

- document the one-time `SCOOP_BUCKET_TOKEN` administrator setup
- specify the fine-grained token scope and target repository
- document release verification and the safe missing-secret behavior

The release workflows and GoReleaser config already wire this variable; adding the Actions secret itself requires organization administrator access and cannot be performed from a fork PR.

## Validation

- `go build -tags extra -o bluefin-cli .`
- `go test -tags extra ./...`
- `git diff --check`

Refs tuna-os/bluefin-cli#91

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/bluefin-cli/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->