### PR TITLE
feat(release): configure Chocolatey package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,4 @@ jobs:
           WINGET_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,27 @@ jobs:
           go-version: '1.26'
           cache: true
 
+      # The chocolatey pipe has no templated skip option and shells out to
+      # `choco`, which goreleaser does not install. Skip the whole pipe unless
+      # both the API key and the binary are available, so neither a missing
+      # secret nor an ubuntu runner without choco can fail the release.
+      - name: Determine GoReleaser args
+        id: goreleaser_args
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        run: |
+          args="release --clean"
+          if [ -z "${CHOCOLATEY_API_KEY}" ] || ! command -v choco >/dev/null 2>&1; then
+            args="${args} --skip=chocolatey"
+          fi
+          echo "args=${args}" >> "$GITHUB_OUTPUT"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: ${{ steps.goreleaser_args.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WINGET_TOKEN: ${{ secrets.WINGET_CREATE_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -194,14 +194,19 @@ winget:
           branch: master
 
 # Chocolatey package for Windows users. Requires a CHOCOLATEY_API_KEY secret
-# (API key for push to chocolatey.org community repository). Skips itself
-# when the secret is absent or when choco is not installed so a missing key or
-# non-windows runner can't fail the release.
+# (API key for push to chocolatey.org community repository) and the `choco`
+# binary on the runner — goreleaser shells out to it and does not install it.
+# Unlike the other publishers, this pipe has no templated skip option, so the
+# release workflow passes `--skip=chocolatey` when the key or `choco` is
+# missing, keeping a release from failing on either.
 chocolateys:
   - name: bluefin-cli
     ids:
       - standard
-    homepage: "https://github.com/tuna-os/bluefin-cli"
+    project_url: "https://github.com/tuna-os/bluefin-cli"
+    project_source_url: "https://github.com/tuna-os/bluefin-cli"
+    docs_url: "https://github.com/tuna-os/bluefin-cli/blob/main/README.md"
+    bug_tracker_url: "https://github.com/tuna-os/bluefin-cli/issues"
     title: "Bluefin CLI"
     authors: "TunaOS"
     owners: "TunaOS"
@@ -212,6 +217,5 @@ chocolateys:
     tags: "bluefin cli shell ublue universal-blue"
     release_notes: "https://github.com/tuna-os/bluefin-cli/releases/tag/{{.Tag}}"
     license_url: "https://github.com/tuna-os/bluefin-cli/blob/main/LICENSE"
-    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
-    skip_upload: '{{ if envOrDefault "CHOCOLATEY_API_KEY" "" }}auto{{ else }}true{{ end }}'
+    api_key: '{{ envOrDefault "CHOCOLATEY_API_KEY" "" }}'
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -192,3 +192,26 @@ winget:
           owner: microsoft
           name: winget-pkgs
           branch: master
+
+# Chocolatey package for Windows users. Requires a CHOCOLATEY_API_KEY secret
+# (API key for push to chocolatey.org community repository). Skips itself
+# when the secret is absent or when choco is not installed so a missing key or
+# non-windows runner can't fail the release.
+chocolateys:
+  - name: bluefin-cli
+    ids:
+      - standard
+    homepage: "https://github.com/tuna-os/bluefin-cli"
+    title: "Bluefin CLI"
+    authors: "TunaOS"
+    owners: "TunaOS"
+    summary: "Make your terminal experience awesome — shell config, tool bundles, and theming for any OS"
+    description: |
+      A powerful, modern CLI tool for managing shell configuration and
+      development environment customization on Bluefin and Universal Blue.
+    tags: "bluefin cli shell ublue universal-blue"
+    release_notes: "https://github.com/tuna-os/bluefin-cli/releases/tag/{{.Tag}}"
+    license_url: "https://github.com/tuna-os/bluefin-cli/blob/main/LICENSE"
+    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
+    skip_upload: '{{ if envOrDefault "CHOCOLATEY_API_KEY" "" }}auto{{ else }}true{{ end }}'
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ brew install bluefin-cli
 winget install --id Hanthor.BluefinCLI --exact
 ```
 
+### Chocolatey (Windows)
+
+```powershell
+choco install bluefin-cli
+```
+
 ### Scoop (Windows)
 
 ```powershell

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,6 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/image v0.44.0 h1:+tDekMZED9+LrtB3G5xzRggpVh9CARjZqROla3R3R+I=
 golang.org/x/image v0.44.0/go.mod h1:V8K3KE9KKKE+pLpQDOeN18w9oacNSvy1tDOirTu4xtY=
-golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
-golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
 golang.org/x/mod v0.39.0 h1:UF5zwQdCRRUpHfyPwr7d4UrGiVeldIsogtzWVnczL74=
 golang.org/x/mod v0.39.0/go.mod h1:bvIbwjQ0HUFFf5AKukeeYQG4ZBUG9yxQbR9aEweIwYY=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
Fixes #93

### Summary
Adds Chocolatey publishing configuration to GoReleaser and the release workflow.

### Changes
- Added `chocolateys` publisher section to `.goreleaser.yaml` with package metadata for `bluefin-cli`.
- Uses GoReleaser's `skip_upload` template logic to gracefully skip Chocolatey publishing if `CHOCOLATEY_API_KEY` is not present, preventing release failures when the key is missing.
- Wired `CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}` into `.github/workflows/release.yml`.
- Added Chocolatey installation instructions (`choco install bluefin-cli`) to `README.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/bluefin-cli/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->