### PR TITLE
docs(readme): document SCOOP_BUCKET_TOKEN secret requirement (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ On Windows, use `go build -o bluefin-cli.exe .`.
 
 Maintainers: package publishing (Homebrew tap, Winget, Scoop) is automated by GoReleaser on release; `.github/workflows/winget.yml` is a manual fallback for re-submitting a Winget version.
 
+Scoop publishing requires the `SCOOP_BUCKET_TOKEN` repository secret (a fine-grained PAT with write access to `tuna-os/scoop-bucket`), without which the Scoop manifest upload step is safely skipped during release workflows. See [docs/release-publishing.md](docs/release-publishing.md) for details.
+
 Homebrew release process: on every tagged release GoReleaser publishes the
 binary formula to `tuna-os/homebrew-tap` (requires the `HOMEBREW_TAP_TOKEN`
 secret). External taps that build from source, such as


### PR DESCRIPTION
Closes #91.

### Summary
- Verified repository workflows (, ) and  configuration.
- Confirmed release pipeline handles  cleanly (skips upload gracefully when absent, publishes to  when present).
- Updated [README.md](file:///home/dev/workspace/tuna-os/bluefin-cli/README.md) maintainer section to reference  requirements and link to [docs/release-publishing.md](file:///home/dev/workspace/tuna-os/bluefin-cli/docs/release-publishing.md).

*Note for Org Admins:* Setting the secret requires an org administrator with write access to repository secrets to create a fine-grained PAT with  on  and save it as  under Actions secrets.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `e295051`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/bluefin-cli/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->