### PR TITLE
ci: widen go.sum auto-tidy to cover hanthor-hive-agent[bot] (#177)

### DIFF
--- a/.github/workflows/dependabot-tidy-fix.yml
+++ b/.github/workflows/dependabot-tidy-fix.yml
@@ -1,12 +1,12 @@
-name: Dependabot go.sum auto-tidy
+name: Bot PRs go.sum auto-tidy
 
-# tuna-os/bluefin-cli#162: `go mod tidy -diff` in ci.yml's go-mod-tidy job
+# tuna-os/bluefin-cli#162 & #177: `go mod tidy -diff` in ci.yml's go-mod-tidy job
 # runs on `pull_request`, where GitHub hard-restricts GITHUB_TOKEN to
-# read-only whenever the PR is authored by dependabot[bot] -- regardless of
+# read-only whenever the PR is authored by dependabot[bot] or bot agents -- regardless of
 # any `permissions:` block declared there. That job can therefore detect
-# staleness on a Dependabot PR but can never push the fix itself. #156
+# staleness on a bot PR but can never push the fix itself. #156
 # already covers the Renovate-authored path (postUpgradeTasks runs `go mod
-# tidy` there), so this workflow only needs to handle Dependabot.
+# tidy` there), so this workflow handles Dependabot and hive agent PRs.
 #
 # `workflow_run` sidesteps the restriction: it runs in the base repo's
 # context with this workflow's own `permissions:` block honored in full,
@@ -23,7 +23,7 @@ permissions:
 jobs:
   fix-tidy:
     # Only chase this for a failed CI run that actually came from a PR (not
-    # push/schedule) authored by dependabot[bot] -- narrowest possible
+    # push/schedule) authored by dependabot[bot] or hanthor-hive-agent[bot] -- narrowest possible
     # trigger before spending a checkout+push on it. `go mod tidy -diff`
     # failing is not distinguished from other CI failures here (the
     # workflow_run event doesn't expose per-job conclusions); the tidy step
@@ -33,7 +33,7 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.actor.login == 'dependabot[bot]'
+      (github.event.workflow_run.actor.login == 'dependabot[bot]' || github.event.workflow_run.actor.login == 'hanthor-hive-agent[bot]')
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -52,11 +52,11 @@ jobs:
           fi
           echo "head_ref=${head_ref}" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout the Dependabot branch
+      - name: Checkout the bot branch
         uses: actions/checkout@v7
         with:
           ref: ${{ steps.pr.outputs.head_ref }}
-          # Dependabot PRs are same-repo branches (not forks), so the
+          # Bot PRs are same-repo branches (not forks), so the
           # default token can push here once given contents: write above.
           persist-credentials: true
 
@@ -76,5 +76,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add go.mod go.sum
-          git commit -m "chore: go mod tidy (auto-fix for Dependabot PR)"
+          git commit -m "chore: go mod tidy (auto-fix for bot PR)"
           git push origin "HEAD:${{ steps.pr.outputs.head_ref }}"


### PR DESCRIPTION
Fixes #177.

### Summary
- Renamed `.github/workflows/dependabot-tidy-fix.yml` to `Bot PRs go.sum auto-tidy`.
- Extended the `workflow_run` actor condition to include `hanthor-hive-agent[bot]` alongside `dependabot[bot]`.
- Updated step descriptions and commit message formatting to be generic for bot PRs.
