### PR TITLE
fix(release): skip winget publish, non-fatal until token is fixed

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -154,6 +154,14 @@ aurs:
       name: tunabot
       email: noreply@github.com
 
+# Temporarily skipped at invocation (--skip=winget in .releaserc.json's
+# publishCmd, not here): WINGET_CREATE_GITHUB_TOKEN is present but 403s
+# against microsoft/winget-pkgs (expired or wrong scope) as of #181,
+# failing the whole Automated Release job even though the GitHub release
+# itself succeeds. .github/workflows/winget.yml (workflow_dispatch) can
+# re-submit any specific version manually once the token is fixed. Remove
+# --skip=winget from .releaserc.json once WINGET_CREATE_GITHUB_TOKEN is
+# verified working again — this config block is otherwise unchanged.
 winget:
   - name: BluefinCLI
     publisher: Hanthor

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,7 +17,7 @@
       "@semantic-release/exec",
       {
         "prepareCmd": "go mod tidy -diff",
-        "publishCmd": "goreleaser release --clean --skip=chocolatey"
+        "publishCmd": "goreleaser release --clean --skip=chocolatey --skip=winget"
       }
     ]
   ]


### PR DESCRIPTION
## Summary

Fixes #181 — a policy trade-off, flagged for maintainer review rather than auto-merge. `WINGET_CREATE_GITHUB_TOKEN` is present but 403s against `microsoft/winget-pkgs` (expired, or wrong scope/owner permissions). `winget.skip_upload`'s templated guard only fires when the token is genuinely empty, not when it's present-but-invalid, so goreleaser attempts the publish and fails the whole `publishCmd` — which fails the entire `Automated Release` job even though the GitHub release itself already succeeded.

## What changed

Adds `--skip=winget` to the `publishCmd` (matching `--skip=chocolatey`, already skipped there for a different reason). goreleaser doesn't expose a per-publisher continue-on-error, and `goreleaser release` is one atomic run across every publisher, so there's no way to make just this one pipe non-fatal while leaving it enabled — a full skip is what the issue's own recommendation #2 suggested.

`.github/workflows/winget.yml` (`workflow_dispatch`) already exists as a manual fallback to re-submit any specific version once the token is verified working again — remove `--skip=winget` from `.releaserc.json` at that point to restore the automatic path.

## Why this is a PR, not just a comment

I don't have repo-secrets access to actually fix `WINGET_CREATE_GITHUB_TOKEN`, and disabling an entire shipping channel (even temporarily) is a product call — opening this for review rather than deciding it unilaterally, but implementing the issue's own suggested mitigation concretely rather than only describing it.

## Test plan

- [x] `python3 -c "import json; json.load(open('.releaserc.json'))"` — valid JSON
- [x] `goreleaser check` — reports only a pre-existing deprecation warning (`brews`, unrelated to this change), no new issues

---
_Generated by [Claude Code](https://claude.ai/code/session_014mkpNM2ZMGG78bAiYM1osn)_