### PR TITLE
Add golangci-lint config and coverage gate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - unconvert
+    - misspell
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 45%
+        threshold: 2%
+    patch:
+      default:
+        target: 70%
+        informational: true
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary

Adds the two ACMM L0 prerequisite files that were genuinely missing from this repo (`CONTRIBUTING.md` already existed and is being closed separately as evidence, not touched here):

- **`.golangci.yml`** — code style config for this Go project, using the v2 schema (this environment's `golangci-lint` is 2.5.0, matching what `golangci-lint-action@v9` runs). CI already invokes `golangci-lint-action` with no checked-in config (defaulting to the `standard` linter set), so this mirrors that invocation and additionally enables `gofmt`/`goimports` as formatters plus `unconvert`/`misspell`, in line with the `gofmt` check this repo's CI already runs as a separate job. Validated locally: `golangci-lint run --config .golangci.yml ./...` → `0 issues`.
- **`codecov.yml`** — coverage gate, in the same style as the existing example at `tuna-os/bootc-installer`. CI already uploads coverage via `codecov/codecov-action`, but had no gate config. Patch coverage is `informational: true` so this cannot fail CI on its own. Validated as well-formed YAML.

No application code, dependencies, or existing CI workflows were touched.

Closes #214
Closes #215