### PR TITLE
chore: tidy go.sum to unblock the go.mod tidy CI job

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 aead.dev/minisign v0.2.0 h1:kAWrq/hBRu4AARY6AlciO83xhNnW9UaC8YipS2uhLPk=
 aead.dev/minisign v0.2.0/go.mod h1:zdq6LdSd9TbuSxchxwhpA9zEb9YXcVGoE8JakuiGaIQ=
-charm.land/bubbles/v2 v2.2.0 h1:9GEMewcejrNtVIxZ9Y2wSsWJamsWNsXa8MpMLnH4yI4=
-charm.land/bubbles/v2 v2.2.0/go.mod h1:wdMgn+sje1KNXdwFizIWjbf328fIUBxqEmJ/vYPo8yc=
 charm.land/bubbles/v2 v2.2.1 h1:Fq1+qm5hV6GkvzLQDhCBpXXE5tLgvh1PRriCLwSvIQU=
 charm.land/bubbles/v2 v2.2.1/go.mod h1:wdMgn+sje1KNXdwFizIWjbf328fIUBxqEmJ/vYPo8yc=
 charm.land/bubbletea/v2 v2.0.9 h1:DpJCMWKgzQK8SJv4zbKKFHAI10ymWy/evClPFk0k0f8=
@@ -38,12 +36,6 @@ github.com/charmbracelet/x/exp/ordered v0.1.0 h1:55/qLwjIh0gL0Vni+QAWk7T/qRVP6sB
 github.com/charmbracelet/x/exp/ordered v0.1.0/go.mod h1:5UHwmG+is5THxMyCJHNPCn2/ecI07aKNrW+LcResjJ8=
 github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 h1:qko3AQ4gK1MTS/de7F5hPGx6/k1u0w4TeYmBFwzYVP4=
 github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0/go.mod h1:pBhA0ybfXv6hDjQUZ7hk1lVxBiUbupdw5R31yPUViVQ=
-github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260816001655-68d539dca504 h1:fDsPREsmS3KGgpqhk9e2s1Q1fTdW6n/9E9+jGpmuf7k=
-github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260816001655-68d539dca504/go.mod h1:aRoQwQWmN9LBG2xi3sVByMFt2fdkPCagd0GAJ1qwOfw=
-github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260823001701-96af6d2cb5f6 h1:Dyn8q73HYvQZdyKfwqQCM083FNurwGc4uvbJvP3ak6g=
-github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260823001701-96af6d2cb5f6/go.mod h1:aRoQwQWmN9LBG2xi3sVByMFt2fdkPCagd0GAJ1qwOfw=
-github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260830003929-9f48cc723c1c h1:qZlwbXAdR9Fx0iKCO5VXPlENmZg1p5d/UYRdq9wQ4Pg=
-github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260830003929-9f48cc723c1c/go.mod h1:aRoQwQWmN9LBG2xi3sVByMFt2fdkPCagd0GAJ1qwOfw=
 github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260901172002-a5dee49b2863 h1:wkh1r5Aj82JW8+oVYf+C108FQe1YJNq4v4NAm/SoQIY=
 github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260901172002-a5dee49b2863/go.mod h1:aRoQwQWmN9LBG2xi3sVByMFt2fdkPCagd0GAJ1qwOfw=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=


### PR DESCRIPTION
## What

`go mod tidy` on `main` removes eight stale `go.sum` lines left behind by earlier Renovate bumps:

- `charm.land/bubbles/v2 v2.2.0` — superseded by `v2.2.1`
- `github.com/charmbracelet/x/exp/teatest/v2` pseudo-versions `20260816001655`, `20260823001701` and `20260830003929` — superseded by `20260901172002`

`go.mod` is unchanged; only the redundant hashes go away.

## Why

This is the drift the repo guide calls out as a landmine. `go build` and `go test` ignore stale `go.sum` lines, so the drift passes CI — then the release job's `go mod tidy` rewrites the files and goreleaser aborts with "git is in a dirty state", *after* the tag and GitHub release already exist. The `go.mod tidy` job has been red on `main` because of it.

## Validation

Run locally against current `main`:

- `go build ./...` — passes
- `go build -tags extra ./...` — passes
- `go test -tags extra ./...` — all packages pass (integration binary built to the repo root first, as the integration tests exec `./bluefin-cli`)