### PR TITLE
ci: cover Renovate PRs in the bot go.sum auto-tidy workflow

### DIFF
--- a/.github/workflows/dependabot-tidy-fix.yml
+++ b/.github/workflows/dependabot-tidy-fix.yml
@@ -4,9 +4,15 @@ name: Bot PRs go.sum auto-tidy
 # runs on `pull_request`, where GitHub hard-restricts GITHUB_TOKEN to
 # read-only whenever the PR is authored by dependabot[bot] or bot agents -- regardless of
 # any `permissions:` block declared there. That job can therefore detect
-# staleness on a bot PR but can never push the fix itself. #156
-# already covers the Renovate-authored path (postUpgradeTasks runs `go mod
-# tidy` there), so this workflow handles Dependabot and hive agent PRs.
+# staleness on a bot PR but can never push the fix itself.
+#
+# Renovate is covered here too (#219). #156 assumed renovate.json's
+# postUpgradeTasks would tidy those branches, but `postUpgradeTasks` is
+# only executed by self-hosted Renovate with the command allowlisted via
+# `allowedPostUpgradeCommands`; the hosted app ignores the block silently,
+# so the config looks correct while never running. #216 is the proof: it
+# merged on 2026-09-01 with `go.mod tidy` red, leaving the stale
+# checksums that then failed main CI and aborted Automated Release.
 #
 # `workflow_run` sidesteps the restriction: it runs in the base repo's
 # context with this workflow's own `permissions:` block honored in full,
@@ -23,8 +29,8 @@ permissions:
 jobs:
   fix-tidy:
     # Only chase this for a failed CI run that actually came from a PR (not
-    # push/schedule) authored by dependabot[bot] or hanthor-hive-agent[bot] -- narrowest possible
-    # trigger before spending a checkout+push on it. `go mod tidy -diff`
+    # push/schedule) authored by one of the dependency/agent bots -- narrowest
+    # possible trigger before spending a checkout+push on it. `go mod tidy -diff`
     # failing is not distinguished from other CI failures here (the
     # workflow_run event doesn't expose per-job conclusions); the tidy step
     # below is itself the real gate -- it only commits/pushes if there is
@@ -33,7 +39,9 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.event == 'pull_request' &&
-      (github.event.workflow_run.actor.login == 'dependabot[bot]' || github.event.workflow_run.actor.login == 'hanthor-hive-agent[bot]')
+      (github.event.workflow_run.actor.login == 'dependabot[bot]' ||
+      github.event.workflow_run.actor.login == 'renovate[bot]' ||
+      github.event.workflow_run.actor.login == 'hanthor-hive-agent[bot]')
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
Follow-up to #224, which tidied the lockfile. This addresses the *recurrence* half of #219.

## The gap

`dependabot-tidy-fix.yml` chases `go mod tidy` staleness on Dependabot and hive-agent PRs, but deliberately skips Renovate. Its own comment explains why:

> `#156` already covers the Renovate-authored path (postUpgradeTasks runs `go mod tidy` there), so this workflow handles Dependabot and hive agent PRs.

**That assumption does not hold.** `renovate.json` does declare it:

```json
"postUpgradeTasks": {
  "commands": ["go mod tidy"],
  "fileFilters": ["go.mod", "go.sum"],
  "executionMode": "update"
}
```

but `postUpgradeTasks` is only executed by **self-hosted** Renovate with the command allowlisted through `allowedPostUpgradeCommands`. The hosted app ignores the block silently — no warning, no failed run. So the config reads as correct to anyone auditing it while never having run once, and the one path that was assumed to be covered was in fact the only uncovered one.

## Evidence

#216 merged on 2026-09-01 with the `go.mod tidy` check red, leaving the superseded `teatest/v2` and `bubbles/v2` checksums behind. Main CI then failed the same check, and the Automated Release run aborted, because semantic-release runs `go mod tidy` and found a dirty tree — the exact failure mode the repo guide describes, where the tag and GitHub release already exist by the time goreleaser gives up. #224 cleaned up the resulting drift; without this change the next patch or digest bump reintroduces it.

## The change

Adds `renovate[bot]` to the actor list in the `if:`, and rewrites the stale comment to record why the postUpgradeTasks route cannot be relied on.

Widening the trigger cannot produce spurious commits: the tidy step is its own gate and commits only when `go mod tidy` actually produces a diff, so a run triggered by an unrelated CI failure stays a no-op. That property is already documented in the job's comment and is unchanged here.

## Not covered by this PR

`go.mod tidy` is not a required status check, so `platformAutomerge` will still merge a Renovate PR the moment the required checks pass — potentially before this workflow's `workflow_run` fires. Making `go.mod tidy` required in branch protection is the durable fix for that race and needs a repository admin; I have left #219 open with this noted.