### PR TITLE
chore: add repo scaffolding (EditorConfig, code owners)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[*.{sh,bash}]
+indent_style = space
+indent_size = 2
+
+[*.ps1]
+indent_style = space
+indent_size = 4
+
+[{Containerfile,Dockerfile}*]
+indent_style = space
+indent_size = 4
+
+[{justfile,Justfile}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hanthor


### PR DESCRIPTION
## Summary

Two contributor-facing files this repo did not have. No source changes. `AGENTS.md` and `CLAUDE.md` already exist here and are untouched.

- **`.editorconfig`** — generated from the file types this repo actually contains (8 sections). `.go` gets `indent_style = tab` to match gofmt rather than fighting it; there are also `.sh`, `.ps1`, Containerfile and justfile blocks, since this repo genuinely ships all of them.
- **`.github/CODEOWNERS`** — `* @hanthor`.

PR and issue templates are deliberately **not** added: `tuna-os/.github` already serves those org-wide to every public repo without its own, so a local copy would only drift from the central one.

## Testing

Nothing executable changed — two files added, none modified. `.editorconfig` only affects editors and cannot alter the tree on its own; in particular it does not touch `go.mod`/`go.sum`, so the tidy-drift trap described in `AGENTS.md` is not in play here.

## Checklist

- [ ] Commit messages are signed-off (`git commit -s`) — DCO required — *not added: I'm not able to attest a DCO sign-off on a maintainer's behalf.*
- [x] `just fix` passes locally (format + lint) — n/a, no code changed
- [x] Tests pass (`just test` / relevant CI workflow) — n/a; CI will confirm
- [x] No secrets or machine-specific paths are committed
- [x] Changelog / docs updated if user-visible behavior changed — n/a

## Related

- References: ACMM Tier A — `acmm:editor-config`, `aef:structural-gates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_